### PR TITLE
The added Makefile makes this template work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+all: main
+
+CXX = clang++
+override CXXFLAGS += -g -Wno-everything
+
+SRCS = $(shell find . -name '.ccls-cache' -type d -prune -o -type f -name '*.cpp' -print | sed -e 's/ /\\ /g')
+HEADERS = $(shell find . -name '.ccls-cache' -type d -prune -o -type f -name '*.h' -print)
+
+main: $(SRCS) $(HEADERS)
+	$(CXX) $(CXXFLAGS) $(SRCS) -o "$@"
+
+main-debug: $(SRCS) $(HEADERS)
+	$(CXX) $(CXXFLAGS) -O0 $(SRCS) -o "$@"
+
+clean:
+	rm -f main main-debug


### PR DESCRIPTION
It seem that just adding the makefile to the project makes the project work on Repl.it. This solves my issue [here](https://github.com/DAChenScratch/Starter-Battlesnake-Cpp-with-replit/issues/3), however the console has a different output this time:
```diff
-> sh -c make -s
-make: *** No targets specified and no makefile found.  Stop.
-exit status 2

+> sh -c make -s
+> bash run.bash
+This can take some time, there are over 30000 lines of code to compile in the libraries...
+run.bash: line 2: clang++-7: command not found
```
